### PR TITLE
Correctly handle bad characters

### DIFF
--- a/python/lean_step.py
+++ b/python/lean_step.py
@@ -381,14 +381,19 @@ def create_datasets(data_dir: str, dest_dir: str):
     json_files = files_with_extension(data_dir, "json")
     print("JSON FILES: ", json_files)
     for json_file in tqdm(json_files):
-        with open(json_file, "r") as json_file_handle:
-            for json_line in json_file_handle:
-                try:
-                    dp = json.loads(json_line)
-                    for dc in dataset_creators:
-                        dc.process_dp(dp)
-                except Exception as e:
-                    print(f"BAD LINE IN FILE: {json_file} EXCEPTION: {e}")
+        line = 0
+        try:
+            with open(json_file, "r") as json_file_handle:
+                for json_line in json_file_handle:
+                    line += 1
+                    try:
+                        dp = json.loads(json_line)
+                        for dc in dataset_creators:
+                            dc.process_dp(dp)
+                    except Exception as e:
+                        print(f"BAD LINE IN FILE: {json_file} EXCEPTION: {e}")
+        except Exception as e:
+            print(f"BAD FILE: {json_file} LINE: {line}: EXCEPTION: {e}")
 
 
 def create_lm_sequence(dp_json):


### PR DESCRIPTION
Probably due to line truncation:
```
Traceback (most recent call last):                                                                                                                                                                                                                                                                     File "python/lean_step.py", line 421, in <module>                                                                                                                                                                                                                                                  
    create_datasets(**vars(opts))                                                                                                                                                                                                                                                                      File "python/lean_step.py", line 385, in create_datasets                                                                                                                                                                                                                                           
    for json_line in json_file_handle:                                                                                                                                                                                                                                                               
  File "/opt/conda/lib/python3.7/codecs.py", line 322, in decode                                                                                                                                                                                                                                     
    (result, consumed) = self._buffer_decode(data, self.errors, final)                                                                                                                                                                                                                               
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf0 in position 0: unexpected end of data     
```