### PR TITLE
Bump lean3 and mathlib; fix extraction script

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lean-step"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.33.0"
+lean_version = "leanprover-community/lean:3.35.1"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "2fd713a76e15eebdcdfd2f94472584b3f5f2bfc7"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "ebdbe6b00344560e39edec913f63ddb1f6546bdf"}

--- a/src/tools/all_decls.lean
+++ b/src/tools/all_decls.lean
@@ -12,7 +12,8 @@ meta def main : io unit := do {
   f ← io.mk_file_handle dest io.mode.append,
   io.run_tactic' $ do {
     env ← get_env,
-    decls ← list.filter (λ d, !(ignore_decls_fn env d)) <$> lint_mathlib_decls,
+    mathlib_dir ← get_mathlib_dir,
+    decls ← list.filter (λ d, !(ignore_decls_fn env d)) <$> (lint_project_decls mathlib_dir),
     for_ decls $ λ decl, do {
       let decl_name := decl.to_name.to_string,
       tactic.unsafe_run_io $ io.fs.put_str_ln f decl_name,

--- a/src/tools/all_decls_jsonline.lean
+++ b/src/tools/all_decls_jsonline.lean
@@ -25,7 +25,8 @@ meta def main : io unit := do {
 
   io.run_tactic' $ do {
     env ← get_env,
-    decls ← list.filter (λ d, !(ignore_decls_fn env d)) <$> lint_mathlib_decls,
+    mathlib_dir ← get_mathlib_dir,
+    decls ← list.filter (λ d, !(ignore_decls_fn env d)) <$> (lint_project_decls mathlib_dir),
     for_ decls $ λ decl, do {
       msg ← mk_decl_msg decl,
       tactic.unsafe_run_io $ io.fs.put_str_ln f msg,


### PR DESCRIPTION
Bumps mathlib and adapts the extraction script to the new version (`lint_mathlib_decls` was removed from mathlib.)

Tested by generating the dataset (though understandably generation took much longer). 