### PR TITLE
Fix tiny Python grammar error that a method does not have `self` as argument

### DIFF
--- a/python/lean_step.py
+++ b/python/lean_step.py
@@ -104,7 +104,7 @@ class DatasetCreator:
     def __init__(self, fp):
         self.fp = fp
 
-    def process_dp(dp):
+    def process_dp(self, dp):
         raise NotImplementedError
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5236035/209953554-0d25f5b7-2f54-40c0-b346-e66aa2d89c10.png)
![image](https://user-images.githubusercontent.com/5236035/209953567-bbf3e6d0-69b6-4f3a-8e0a-40b37706126b.png)
